### PR TITLE
Fix: Ajuste de declaração de variavel do campo name

### DIFF
--- a/src/Commands/DoctrineHydratorCommand.php
+++ b/src/Commands/DoctrineHydratorCommand.php
@@ -25,7 +25,7 @@ class DoctrineHydratorCommand extends HyperfCommand
     /**
      * @var string
      */
-    protected $name = 'doctrine:generate-hydrators';
+    protected ?string $name = 'doctrine:generate-hydrators';
 
     /**
      * @param ContainerInterface $container

--- a/src/Commands/DoctrinePersistentCollectionCommand.php
+++ b/src/Commands/DoctrinePersistentCollectionCommand.php
@@ -26,7 +26,7 @@ class DoctrinePersistentCollectionCommand extends HyperfCommand
     /**
      * @var string
      */
-    protected $name = 'doctrine:generate-persistent-collections';
+    protected ?string $name = 'doctrine:generate-persistent-collections';
 
     /**
      * @param ContainerInterface $container

--- a/src/Commands/DoctrineProxyCommand.php
+++ b/src/Commands/DoctrineProxyCommand.php
@@ -27,7 +27,7 @@ class DoctrineProxyCommand extends HyperfCommand
     /**
      * @var string
      */
-    protected $name = 'doctrine:generate-proxies';
+    protected ?string $name = 'doctrine:generate-proxies';
 
     /**
      * @param ContainerInterface $container


### PR DESCRIPTION
Fiz esse ajuste por conta de nos testes do repositorio lib-payments-commons estava quebrando por conta de não ter o tipo da váriavel name como null ou string. 